### PR TITLE
rename examples, remove multiple different root keys, improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@
 ```
  node example/json2def.js
 ```
+
+### Additionaly
+
+```bash
+node --experimental-modules --experimental-specifier-resolution=node ~/.dmt/core/node/common/cli/parseDef.js example/example.def
+```
+
+### Def format specification and motivation
+
+[See here](https://github.com/dmtsys/def)

--- a/example/def2json.js
+++ b/example/def2json.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const { def2json } = require('..');
 
-const def = fs.readFileSync('example/def', 'utf-8');
+const def = fs.readFileSync('example/example.def', 'utf-8');
 
 console.log(JSON.stringify(def2json(def), undefined, 2));

--- a/example/example.def
+++ b/example/example.def
@@ -26,17 +26,3 @@ pushover:
 
       token: gcxf961e396afdto1u3nqi6cxb63mw
 
-pushhere:
-
-  app: foo#fghjh
-
-    token: a8!kog2np8viz4jmm17ev93tmosp89k
-
-    group: red
-
-      token: g1xf961e396afdto1u3nqi6cxb63mv
-
-    group: blue
-
-      token: gcxf961e396afdto1u3nqi6cxb63mw
-

--- a/example/example.json
+++ b/example/example.json
@@ -37,25 +37,5 @@
                 }
             ]
         }
-    ],
-    "pushhere": [
-        {
-            "app": [
-                {
-                    "__name__": "foo#fghjh",
-                    "token": "a8!kog2np8viz4jmm17ev93tmosp89k",
-                    "group": [
-                        {
-                            "__name__": "blue",
-                            "token": "gcxf961e396afdto1u3nqi6cxb63mw"
-                        },
-                        {
-                            "__name__": "red",
-                            "token": "g1xf961e396afdto1u3nqi6cxb63mv"
-                        }
-                    ]
-                }
-            ]
-        }
     ]
 }

--- a/example/json2def.js
+++ b/example/json2def.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const { json2def } = require('..');
 
-const json = JSON.parse(fs.readFileSync('example/json', 'utf-8'));
+const json = JSON.parse(fs.readFileSync('example/example.json', 'utf-8'));
 
 console.log(json2def(json));


### PR DESCRIPTION
Hey, interesting.

I was delaying implementation of `json → def` for these reasons:

- wasn't sure how easy it would be
- had other priorities
- this is a bit dangerous and if we have this capability then we can actually implement editing of configurations from GUIs and keep using .def files as storage... I'm not sure if this is good, maybe .def should only be edited through text editor and not via dmt apps... these stable configs can move to some other definition place... not yet sure about all of this but anyway having `json → def` capability (well tested and working) is great and then we can use it or not

not sure how comments would be retained though?

So working `def → json` parser is [here](https://github.com/uniqpath/dmt/blob/main/core/node/common/lib/parsers/def/parser.js)
you did it much shorter https://github.com/Anyass3/dmt-defJson/blob/main/index.js#L1-L36

I will test, think and further document...

this is good work and due to some documenting / stability and even having the reverse capability as you are doing
